### PR TITLE
chore(deps): bump nts to ^1.4.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: nts
-      sha256: d484cf32d8c08fda4eef676be45bb07fe016e47032a486c0f1919936e712415a
+      sha256: "931adb9b779455a6fb36c1a614b549f260b2320b62d9c7bcfa618f73fa5d1d8c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  nts: ^1.3.1
+  nts: ^1.4.0
   http: ">=1.0.0 <2.0.0"
   flutter_secure_storage: ^10.0.0
   ntp: ^2.0.0


### PR DESCRIPTION
## Summary

Bumps the `nts` dependency from `^1.3.1` to `^1.4.0`. `nts` 1.4.0 ships
the `rustls-platform-verifier` initialization fix that resolves a hard
crash during the first NTS-KE handshake on Android.

## Why

On Android, calling into `package:nts` for the first time previously
triggered:

```
PanicException(Expect rustls-platform-verifier to be initialized
Backtrace [{ fn: "_ZL15__pthread_startPv...." },
           { fn: "__start_thread" }])
```

The panic originated inside the `rustls-platform-verifier` Rust crate
that `package:nts` uses for TLS 1.3 certificate verification during the
NTS-KE handshake. On Android that crate requires explicit JNI-side
initialization which `package:nts` 1.3.x did not perform. 1.4.0 wires
this initialization correctly, so any caller can construct an NTS
source on Android without crashing.

## What changed

- `pubspec.yaml`: `nts: ^1.3.1` → `nts: ^1.4.0`
- `example/pubspec.lock`: refreshed to resolve `nts: 1.4.0`

No source code changes. No transitive dependency surprises (`flutter
pub outdated` clean for runtime deps).

## Test plan

- [x] `flutter analyze` (root + example): clean
- [x] `flutter test` (root): all pass
- [x] `flutter test` (example): all pass
- [x] End-to-end validation on a physical Pixel Tablet with the example
      app: NTS source now produces samples with `auth=verified` and is
      incorporated into the consensus result. Previous panic is no
      longer reproducible.

## Notes

This change pairs with several follow-up PRs that build on a working
NTS source. It is independent of all of them and safe to land first.
