### PR TITLE
chore(models): add TrustedTimeConfig.copyWith

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -137,6 +137,50 @@ final class TrustedTimeConfig {
   /// The interval at which the engine should perform a background synchronization.
   /// If null, background synchronization is disabled.
   final Duration? backgroundSyncInterval;
+
+  /// Returns a new [TrustedTimeConfig] with the supplied fields replaced.
+  ///
+  /// Any field omitted (or passed as `null`) keeps its current value.
+  /// [backgroundSyncInterval] cannot be cleared back to `null` through
+  /// this method; construct a new instance directly if that is needed.
+  TrustedTimeConfig copyWith({
+    List<String>? ntpServers,
+    List<String>? httpsSources,
+    List<String>? ntsServers,
+    int? ntsPort,
+    List<TimeSource>? additionalSources,
+    double? minQuorumRatio,
+    int? minimumQuorum,
+    int? minGroupCount,
+    Duration? maxLatency,
+    Duration? refreshInterval,
+    int? maxAllowedUncertaintyMs,
+    bool? persistState,
+    bool? earlyExit,
+    double? oscillatorDriftFactor,
+    Duration? backgroundSyncInterval,
+  }) {
+    return TrustedTimeConfig(
+      ntpServers: ntpServers ?? this.ntpServers,
+      httpsSources: httpsSources ?? this.httpsSources,
+      ntsServers: ntsServers ?? this.ntsServers,
+      ntsPort: ntsPort ?? this.ntsPort,
+      additionalSources: additionalSources ?? this.additionalSources,
+      minQuorumRatio: minQuorumRatio ?? this.minQuorumRatio,
+      minimumQuorum: minimumQuorum ?? this.minimumQuorum,
+      minGroupCount: minGroupCount ?? this.minGroupCount,
+      maxLatency: maxLatency ?? this.maxLatency,
+      refreshInterval: refreshInterval ?? this.refreshInterval,
+      maxAllowedUncertaintyMs:
+          maxAllowedUncertaintyMs ?? this.maxAllowedUncertaintyMs,
+      persistState: persistState ?? this.persistState,
+      earlyExit: earlyExit ?? this.earlyExit,
+      oscillatorDriftFactor:
+          oscillatorDriftFactor ?? this.oscillatorDriftFactor,
+      backgroundSyncInterval:
+          backgroundSyncInterval ?? this.backgroundSyncInterval,
+    );
+  }
 }
 
 @immutable

--- a/test/concurrency_test.dart
+++ b/test/concurrency_test.dart
@@ -167,24 +167,3 @@ void main() {
     );
   });
 }
-
-extension on TrustedTimeConfig {
-  TrustedTimeConfig copyWith({
-    List<TimeSource>? additionalSources,
-    int? minimumQuorum,
-    bool? earlyExit,
-    int? minGroupCount,
-  }) {
-    return TrustedTimeConfig(
-      ntpServers: ntpServers,
-      httpsSources: httpsSources,
-      additionalSources: additionalSources ?? this.additionalSources,
-      minimumQuorum: minimumQuorum ?? this.minimumQuorum,
-      earlyExit: earlyExit ?? this.earlyExit,
-      minGroupCount: minGroupCount ?? this.minGroupCount,
-      persistState: persistState,
-      refreshInterval: refreshInterval,
-      maxLatency: maxLatency,
-    );
-  }
-}


### PR DESCRIPTION
## Summary

Adds an immutable `copyWith` helper to `TrustedTimeConfig` covering all
15 configuration fields. Removes a local test-only `copyWith` extension
in `test/concurrency_test.dart` that the production method now shadows.

## Why

`TrustedTimeConfig` is immutable, which is the right design — but
without a `copyWith`, any caller who needs to derive a modified config
(for tests, for runtime profile switching, or for failure-path
fallbacks) has to manually reconstruct the instance and re-list every
parameter. That is verbose, error-prone, and silently breaks any time
a new field is added to `TrustedTimeConfig`: the manual reconstruction
will drop the new field on the floor.

Adding `copyWith` makes immutable updates ergonomic and forward-
compatible.

## API shape

```dart
final tightened = config.copyWith(
  maxLatency: const Duration(seconds: 2),
  refreshInterval: const Duration(minutes: 15),
);
```

All parameters are nullable; omitted parameters keep their current
value. One documented limitation: `backgroundSyncInterval` cannot be
cleared back to `null` via `copyWith` (since `null` would be
indistinguishable from "omitted"). Callers needing that edge case
should construct a new instance directly. This is called out in the
dartdoc.

## What changed

- `lib/src/models.dart`: adds the `copyWith` method (44 lines incl.
  dartdoc)
- `test/concurrency_test.dart`: removes the local test-only `copyWith`
  extension (21 lines deleted) — the production method now provides
  the same behaviour and the existing test call sites continue to work
  unchanged

## Test plan

- [x] `flutter analyze` (root + example): clean
- [x] `flutter test` (root): all pass — including the 6 existing call
      sites in `concurrency_test.dart` that previously used the local
      extension
- [x] `flutter test` (example): all pass
