### PR TITLE
feat(nts,sync): startup FRB init + per-source two-phase warming pipeline

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: nts
-      sha256: d484cf32d8c08fda4eef676be45bb07fe016e47032a486c0f1919936e712415a
+      sha256: ba5acfa1e0dbb00b739e97c318b357ddad22877970000250b3fc61ec8f1c6d10
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "2.0.0"
   objective_c:
     dependency: transitive
     description:

--- a/lib/src/domain/time_source.dart
+++ b/lib/src/domain/time_source.dart
@@ -20,3 +20,20 @@ abstract interface class TimeSource {
   /// Queries the remote authority and returns a [TimeSample].
   Future<TimeSample> getTime();
 }
+
+/// Optional capability for [TimeSource]s that need a one-time setup
+/// step (handshakes, key exchange, cache priming) which should
+/// complete *outside* the per-query latency budget.
+///
+/// [SyncEngine] type-checks each active source for this interface and
+/// runs [warm] before the timed query phase. Sources that do not need
+/// warming should not implement this; they will be queried directly.
+///
+/// Implementations should be idempotent and tolerate repeated
+/// invocation. They must not throw; failures should be handled
+/// internally so that [TimeSource.getTime] can still attempt a
+/// cold-start query.
+abstract interface class Warmable {
+  /// Performs the source's one-time setup work.
+  Future<void> warm();
+}

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -67,3 +67,23 @@ final class TrustedTimePersistenceException implements Exception {
   @override
   String toString() => 'TrustedTimePersistenceException: $message';
 }
+
+/// Thrown by a `TimeSource` to signal that the failure was transient and
+/// the source should be retried on the next sync cycle without the
+/// exponential cooldown that other failures incur.
+///
+/// Example: an `NtsSource` whose `ntsQuery` returned
+/// `NtsError.timeout(TimeoutPhase.dnsSaturation)` because the bounded DNS
+/// resolver pool was momentarily full. The host itself is healthy; the
+/// next cycle will probably succeed once peers release their resolver
+/// slots, so blacklisting the source for minutes would be incorrect.
+final class TransientSourceError implements Exception {
+  /// Creates a [TransientSourceError] wrapping the underlying [cause].
+  const TransientSourceError(this.cause);
+
+  /// The original error that the source classified as transient.
+  final Object cause;
+
+  @override
+  String toString() => 'TransientSourceError: $cause';
+}

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -137,6 +137,50 @@ final class TrustedTimeConfig {
   /// The interval at which the engine should perform a background synchronization.
   /// If null, background synchronization is disabled.
   final Duration? backgroundSyncInterval;
+
+  /// Returns a new [TrustedTimeConfig] with the supplied fields replaced.
+  ///
+  /// Any field omitted (or passed as `null`) keeps its current value.
+  /// [backgroundSyncInterval] cannot be cleared back to `null` through
+  /// this method; construct a new instance directly if that is needed.
+  TrustedTimeConfig copyWith({
+    List<String>? ntpServers,
+    List<String>? httpsSources,
+    List<String>? ntsServers,
+    int? ntsPort,
+    List<TimeSource>? additionalSources,
+    double? minQuorumRatio,
+    int? minimumQuorum,
+    int? minGroupCount,
+    Duration? maxLatency,
+    Duration? refreshInterval,
+    int? maxAllowedUncertaintyMs,
+    bool? persistState,
+    bool? earlyExit,
+    double? oscillatorDriftFactor,
+    Duration? backgroundSyncInterval,
+  }) {
+    return TrustedTimeConfig(
+      ntpServers: ntpServers ?? this.ntpServers,
+      httpsSources: httpsSources ?? this.httpsSources,
+      ntsServers: ntsServers ?? this.ntsServers,
+      ntsPort: ntsPort ?? this.ntsPort,
+      additionalSources: additionalSources ?? this.additionalSources,
+      minQuorumRatio: minQuorumRatio ?? this.minQuorumRatio,
+      minimumQuorum: minimumQuorum ?? this.minimumQuorum,
+      minGroupCount: minGroupCount ?? this.minGroupCount,
+      maxLatency: maxLatency ?? this.maxLatency,
+      refreshInterval: refreshInterval ?? this.refreshInterval,
+      maxAllowedUncertaintyMs:
+          maxAllowedUncertaintyMs ?? this.maxAllowedUncertaintyMs,
+      persistState: persistState ?? this.persistState,
+      earlyExit: earlyExit ?? this.earlyExit,
+      oscillatorDriftFactor:
+          oscillatorDriftFactor ?? this.oscillatorDriftFactor,
+      backgroundSyncInterval:
+          backgroundSyncInterval ?? this.backgroundSyncInterval,
+    );
+  }
 }
 
 @immutable

--- a/lib/src/sources/nts_source.dart
+++ b/lib/src/sources/nts_source.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:nts/nts.dart' as nts;
 
 import '../domain/time_sample.dart';
 import '../domain/time_source.dart';
 import '../domain/time_interval.dart';
+import '../exceptions.dart';
 import '../models.dart';
 import 'nts_auth_level.dart';
 
@@ -24,10 +26,25 @@ import 'nts_auth_level.dart';
 /// empty (the default), no NTS connections are made.
 final class NtsSource implements TimeSource {
   /// Creates an NTS source for the given NTS-KE server.
-  NtsSource(this._host, {int port = 4460}) : _port = port;
+  ///
+  /// [maxLatency] is forwarded as `ntsQuery`'s `timeoutMs`. [SyncEngine]
+  /// passes [TrustedTimeConfig.maxLatency] so the inner per-query budget
+  /// matches the outer `.timeout(_config.maxLatency)` wrapper. Without
+  /// this, an inner timeout longer than the outer would always be
+  /// pre-empted by Dart's `TimeoutException`, swallowing the
+  /// phase-tagged `NtsError.timeout(TimeoutPhase)` payload that drives
+  /// the [TransientSourceError] cooldown-bypass path. The default of 5 s
+  /// preserves the prior hardcoded behaviour for direct callers.
+  NtsSource(
+    this._host, {
+    int port = 4460,
+    Duration maxLatency = const Duration(seconds: 5),
+  }) : _port = port,
+       _timeoutMs = maxLatency.inMilliseconds;
 
   final String _host;
   final int _port;
+  final int _timeoutMs;
 
   @override
   String get id => '${TimeSource.prefixNts}$_host';
@@ -42,11 +59,36 @@ final class NtsSource implements TimeSource {
 
   @override
   Future<TimeSample> getTime() async {
-    // Use package:nts for full RFC 8915 compliant NTS query
-    final result = await nts.ntsQuery(
-      spec: nts.NtsServerSpec(host: _host, port: _port),
-      timeoutMs: 5000,
-    );
+    final nts.NtsTimeSample result;
+    try {
+      result = await nts.ntsQuery(
+        spec: nts.NtsServerSpec(host: _host, port: _port),
+        timeoutMs: _timeoutMs,
+      );
+    } on nts.NtsError_Timeout catch (e) {
+      // Dns(Saturation) means the bounded DNS resolver pool was at
+      // capacity for this call. The host itself is healthy; SyncEngine
+      // should retry on the next cycle without applying exponential
+      // cooldown. Other timeout phases (Connect, Tls, KeRecordIo, Ntp,
+      // DnsTimeout) propagate as-is and follow the standard cooldown
+      // path.
+      if (e.field0 == nts.TimeoutPhase.dnsSaturation) {
+        throw TransientSourceError(e);
+      }
+      rethrow;
+    }
+
+    if (kDebugMode) {
+      final p = result.phaseTimings;
+      debugPrint(
+        '[TrustedTime] nts:$_host '
+        'rtt=${(result.roundTripMicros / 1000).toStringAsFixed(1)}ms '
+        'dns=${(p.dnsMicros / 1000).toStringAsFixed(1)}ms '
+        'connect=${(p.connectMicros / 1000).toStringAsFixed(1)}ms '
+        'tls=${(p.tlsHandshakeMicros / 1000).toStringAsFixed(1)}ms '
+        'ke=${(p.keRecordIoMicros / 1000).toStringAsFixed(1)}ms',
+      );
+    }
 
     // Calculate uncertainty from network RTT (convert microseconds to milliseconds)
     final uncertaintyMs = result.roundTripMicros ~/ 2000;

--- a/lib/src/sources/nts_source.dart
+++ b/lib/src/sources/nts_source.dart
@@ -19,12 +19,23 @@ import 'nts_auth_level.dart';
 /// - AES-SIV-CMAC-256 authenticated encryption
 /// - Secure NTPv4 extension field handling
 ///
+/// **Cookie jar lifecycle:** [warm] runs [ntsWarmCookies] to perform the
+/// NTS-KE handshake (TCP + TLS + KE, ~3 RTTs) and prime the cookie jar.
+/// [SyncEngine] awaits this in its warming phase before starting the
+/// per-query timeout, so the handshake cost falls outside the
+/// `maxLatency` budget. The warm result is memoized; subsequent calls
+/// share the same completed [Future]. Each successful query receives one
+/// fresh cookie in-band, keeping the pool self-sustaining. If warming
+/// fails or is skipped, [getTime] still calls [warm] as a JIT fallback;
+/// when that fails too, [ntsQuery] performs its own cold-start handshake
+/// transparently.
+///
 /// **Platform support:** Android, iOS, macOS, Windows, Linux.
 /// Not available on Web (NTS requires TLS 1.3 with exporters).
 ///
 /// **Zero overhead when unused:** When [TrustedTimeConfig.ntsServers] is
 /// empty (the default), no NTS connections are made.
-final class NtsSource implements TimeSource {
+final class NtsSource implements TimeSource, Warmable {
   /// Creates an NTS source for the given NTS-KE server.
   ///
   /// [maxLatency] is forwarded as `ntsQuery`'s `timeoutMs`. [SyncEngine]
@@ -39,12 +50,16 @@ final class NtsSource implements TimeSource {
     this._host, {
     int port = 4460,
     Duration maxLatency = const Duration(seconds: 5),
-  }) : _port = port,
+  }) : _spec = nts.NtsServerSpec(host: _host, port: port),
        _timeoutMs = maxLatency.inMilliseconds;
 
   final String _host;
-  final int _port;
+  final nts.NtsServerSpec _spec;
   final int _timeoutMs;
+
+  /// Memoized NTS-KE warm task. `null` until [warm] is first invoked,
+  /// so constructing an [NtsSource] never touches the FFI surface.
+  Future<void>? _warmTask;
 
   @override
   String get id => '${TimeSource.prefixNts}$_host';
@@ -58,13 +73,20 @@ final class NtsSource implements TimeSource {
   bool get isSecure => true;
 
   @override
+  Future<void> warm() {
+    return _warmTask ??= _performWarming();
+  }
+
+  @override
   Future<TimeSample> getTime() async {
+    // JIT fallback: ensure warming has been kicked off and completed
+    // before issuing the timed query. SyncEngine normally awaits warm()
+    // in its dedicated warming phase, so this is a no-op in that path.
+    await warm();
+
     final nts.NtsTimeSample result;
     try {
-      result = await nts.ntsQuery(
-        spec: nts.NtsServerSpec(host: _host, port: _port),
-        timeoutMs: _timeoutMs,
-      );
+      result = await nts.ntsQuery(spec: _spec, timeoutMs: _timeoutMs);
     } on nts.NtsError_Timeout catch (e) {
       // Dns(Saturation) means the bounded DNS resolver pool was at
       // capacity for this call. The host itself is healthy; SyncEngine
@@ -90,7 +112,8 @@ final class NtsSource implements TimeSource {
       );
     }
 
-    // Calculate uncertainty from network RTT (convert microseconds to milliseconds)
+    // Calculate uncertainty from network RTT (convert microseconds to
+    // milliseconds).
     final uncertaintyMs = result.roundTripMicros ~/ 2000;
     final timestampMs = result.utcUnixMicros ~/ 1000;
 
@@ -101,8 +124,17 @@ final class NtsSource implements TimeSource {
       ),
       sourceId: id,
       groupId: groupId,
-      // Full RFC 8915 compliance = cryptographic security
       authLevel: NtsAuthLevel.verified,
     );
+  }
+
+  Future<void> _performWarming() async {
+    try {
+      await nts.ntsWarmCookies(spec: _spec);
+    } catch (_) {
+      // Swallow: missing Rust binaries (test envs), TLS failures, etc.
+      // ntsQuery handles a cold-start handshake transparently when the
+      // cookie jar is empty.
+    }
   }
 }

--- a/lib/src/sources/nts_source_stub.dart
+++ b/lib/src/sources/nts_source_stub.dart
@@ -4,7 +4,11 @@ import '../domain/time_source.dart';
 /// NTS time source stub — actual implementation in `nts_source.dart`.
 final class NtsSource implements TimeSource {
   /// Documented.
-  NtsSource(this._host, {int port = 4460});
+  NtsSource(
+    this._host, {
+    int port = 4460,
+    Duration maxLatency = const Duration(seconds: 5),
+  });
 
   final String _host;
 

--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -63,6 +63,38 @@ final class SyncEngine {
 
   int _syncAttempts = 0;
 
+  /// Eagerly invokes [Warmable.warm] on every source that supports it,
+  /// in parallel.
+  ///
+  /// Intended to be called during application bootstrap so per-source
+  /// setup costs (e.g., the NTS-KE TCP+TLS+key-exchange handshake)
+  /// complete before the first [sync] cycle. Without this, those costs
+  /// fall inside cycle 1's wall clock and contaminate sample
+  /// timestamps with hundreds of milliseconds of skew, preventing
+  /// Marzullo intervals from overlapping.
+  ///
+  /// Each [Warmable.warm] is itself idempotent and memoized, so calling
+  /// this method multiple times is safe and cheap. Failures from
+  /// individual sources are swallowed: warming is best-effort, and
+  /// [sync] retains its existing JIT-warm fallback path.
+  Future<void> warmAllSources() async {
+    final warmables = _sources.whereType<Warmable>().toList(
+      growable: false,
+    );
+    if (warmables.isEmpty) return;
+    await Future.wait(
+      warmables.map((s) async {
+        try {
+          await s.warm();
+        } catch (_) {
+          // Same semantics as the warm-phase failure handling in
+          // sync(): swallow so a single misbehaving source cannot
+          // block bootstrap.
+        }
+      }),
+    );
+  }
+
   /// Executes a full synchronization cycle across all healthy sources.
   ///
   /// This method is the primary driver of trust establishment. It races sources,

--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -51,7 +51,7 @@ final class SyncEngine {
     for (final host in _config.ntpServers) NtpSource(host),
     for (final url in _config.httpsSources) HttpsSource(url),
     for (final host in _config.ntsServers)
-      NtsSource(host, port: _config.ntsPort),
+      NtsSource(host, port: _config.ntsPort, maxLatency: _config.maxLatency),
     ..._config.additionalSources,
   ];
 
@@ -333,6 +333,14 @@ final class SyncEngine {
       _sourceHealth[source.id] = 0; // Reset failure count on success
       _blacklistUntil.remove(source.id);
       return sample;
+    } on TransientSourceError catch (e) {
+      // Source classified the failure as transient (e.g. NtsSource saw
+      // NtsError.timeout(TimeoutPhase.dnsSaturation): the DNS resolver
+      // pool was momentarily full). Notify the observer but do not bump
+      // the failure score or blacklist the host — the next sync cycle
+      // is expected to succeed once contention clears.
+      _observer?.onSourceFailed(source.id, e);
+      return null;
     } catch (e) {
       _observer?.onSourceFailed(source.id, e);
 

--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -189,28 +189,46 @@ final class SyncEngine {
         }
       });
 
-      // 2. Launch racing queries
+      // 2. Launch racing queries.
+      //
+      // Each source runs a per-source two-phase sequence concurrently
+      // with the others:
+      //   Phase A — for sources that implement [Warmable], warm() runs
+      //     outside the per-query maxLatency budget, so slow handshakes
+      //     (e.g., NTS-KE) do not eat into the timed query window.
+      //     Sources that don't implement Warmable skip Phase A and
+      //     proceed straight to the query, so they are not blocked by
+      //     slower siblings.
+      //   Phase B — _querySafe() runs the timed getTime() under
+      //     _config.maxLatency.
+      // warm() is wrapped in Future.sync to capture both synchronous
+      // and asynchronous throws so a misbehaving source cannot abort
+      // its own query (we still proceed to _querySafe) nor the batch.
       for (final source in activeSources) {
-        unawaited(
-          _querySafe(source)
-              .then((s) {
-                if (!streamClosed && !sampleController.isClosed) {
-                  sampleController.add(s);
-                }
-              })
-              .catchError((Object e) {
-                _observer?.onSourceFailed(source.id, e);
-                if (!streamClosed && !sampleController.isClosed) {
-                  sampleController.add(
-                    null,
-                  ); // Ensure pendingQueries still decrements
-                }
-              }),
-        );
+        unawaited(() async {
+          if (source is Warmable) {
+            try {
+              await Future.sync(() => (source as Warmable).warm());
+            } catch (e) {
+              _observer?.onSourceFailed(source.id, 'warm: $e');
+            }
+          }
+
+          final sample = await _querySafe(source);
+          if (!streamClosed && !sampleController.isClosed) {
+            sampleController.add(sample);
+          }
+        }());
       }
 
+      // Outer safety timeout. The per-source pipeline runs warm()
+      // outside the maxLatency budget, so this deadline must cover
+      // both phases. Budget = maxLatency (timed query window) + 5s for
+      // a slow NTS-KE handshake (TCP + TLS 1.3 + key exchange,
+      // typically ~1s but up to ~3s on poor networks) + 1s for stream
+      // processing and consensus resolution overhead.
       final anchor = await completer.future.timeout(
-        _config.maxLatency + const Duration(seconds: 1),
+        _config.maxLatency + const Duration(seconds: 6),
         onTimeout: () {
           if (!completer.isCompleted &&
               samples.length >= _config.minimumQuorum) {

--- a/lib/src/trusted_time_impl.dart
+++ b/lib/src/trusted_time_impl.dart
@@ -207,6 +207,14 @@ final class TrustedTimeImpl {
       }
     }
 
+    // Eagerly prime per-source warm state (e.g., NTS cookie jars) so
+    // that the first sync cycle's RTT measurements are not
+    // contaminated by cold-start handshake latency. Sources without a
+    // warm phase are unaffected. This adds the slowest source's
+    // handshake time (typically ~hundreds of ms) to initialize() when
+    // NTS sources are configured.
+    await _syncEngine.warmAllSources();
+
     final persisted = _config.persistState ? await _store.load() : null;
     if (persisted != null) {
       final rebooted = await _monitor.checkRebootOnWarmStart(persisted);

--- a/lib/trusted_time.dart
+++ b/lib/trusted_time.dart
@@ -27,6 +27,7 @@ library;
 
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'package:nts/nts.dart' as nts;
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 import 'src/exceptions.dart';
@@ -89,6 +90,26 @@ abstract final class TrustedTime {
       config = TrustedTimeConfig.web();
     } else {
       config ??= const TrustedTimeConfig();
+    }
+
+    // Initialize the flutter_rust_bridge runtime backing package:nts
+    // before any NtsSource is constructed.  Gated on
+    // ntsServers.isNotEmpty to preserve the package's "zero overhead
+    // when unused" guarantee.  If RustLib.init fails (missing native
+    // assets, architecture mismatch, etc.), strip ntsServers from the
+    // config so SyncEngine never instantiates an NtsSource and the
+    // process falls back to NTP/HTTPS sources for its lifetime.
+    if (config.ntsServers.isNotEmpty) {
+      try {
+        await nts.RustLib.init();
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint(
+            '[TrustedTime] NTS disabled — RustLib.init failed: $e',
+          );
+        }
+        config = config.copyWith(ntsServers: const []);
+      }
     }
 
     await TrustedTimeImpl.init(config);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  nts: ^1.3.1
+  nts: ^2.0.0
   http: ">=1.0.0 <2.0.0"
   flutter_secure_storage: ^10.0.0
   ntp: ^2.0.0

--- a/test/concurrency_test.dart
+++ b/test/concurrency_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trusted_time/src/sync_engine.dart';
 import 'package:trusted_time/src/models.dart';
+import 'package:trusted_time/src/domain/marzullo_engine.dart';
 import 'package:trusted_time/src/domain/time_source.dart';
 import 'package:trusted_time/src/domain/time_sample.dart';
 import 'package:trusted_time/src/domain/time_interval.dart';
+import 'package:trusted_time/src/infra/sync_observer.dart';
 import 'package:trusted_time/src/monotonic_clock.dart';
 
 class MockMonotonicClock implements MonotonicClock {
@@ -35,6 +37,110 @@ class RaceConditionSource implements TimeSource {
       groupId: groupId,
     );
   }
+}
+
+enum WarmingPhase { warmStart, warmEnd, getTimeStart, getTimeEnd }
+
+class WarmingEvent {
+  const WarmingEvent(this.sourceId, this.phase, this.atMs);
+  final String sourceId;
+  final WarmingPhase phase;
+  final int atMs;
+  @override
+  String toString() => '$sourceId/${phase.name}@${atMs}ms';
+}
+
+/// Test source with configurable warm/getTime delays and behaviors that
+/// records every phase transition into a shared event log so tests can
+/// reason about the per-source pipeline ordering and cross-source
+/// concurrency.
+class WarmingTestSource implements TimeSource, Warmable {
+  WarmingTestSource({
+    required this.id,
+    required this.utcMs,
+    required this.events,
+    required this.clock,
+    this.groupId = 'test-group',
+    this.warmDelay = Duration.zero,
+    this.getTimeDelay = const Duration(milliseconds: 20),
+    this.throwSyncFromWarm = false,
+    this.throwAsyncFromWarm = false,
+  });
+
+  @override
+  final String id;
+  @override
+  final String groupId;
+  final int utcMs;
+  final Duration warmDelay;
+  final Duration getTimeDelay;
+  final bool throwSyncFromWarm;
+  final bool throwAsyncFromWarm;
+  final List<WarmingEvent> events;
+  final Stopwatch clock;
+
+  @override
+  Future<void> warm() {
+    events.add(
+      WarmingEvent(id, WarmingPhase.warmStart, clock.elapsedMilliseconds),
+    );
+    if (throwSyncFromWarm) {
+      throw StateError('synchronous warm failure: $id');
+    }
+    return _doWarm();
+  }
+
+  Future<void> _doWarm() async {
+    if (throwAsyncFromWarm) {
+      throw StateError('asynchronous warm failure: $id');
+    }
+    if (warmDelay > Duration.zero) {
+      await Future.delayed(warmDelay);
+    }
+    events.add(
+      WarmingEvent(id, WarmingPhase.warmEnd, clock.elapsedMilliseconds),
+    );
+  }
+
+  @override
+  Future<TimeSample> getTime() async {
+    events.add(
+      WarmingEvent(id, WarmingPhase.getTimeStart, clock.elapsedMilliseconds),
+    );
+    if (getTimeDelay > Duration.zero) {
+      await Future.delayed(getTimeDelay);
+    }
+    events.add(
+      WarmingEvent(id, WarmingPhase.getTimeEnd, clock.elapsedMilliseconds),
+    );
+    return TimeSample(
+      interval: TimeInterval(startMs: utcMs - 10, endMs: utcMs + 10),
+      sourceId: id,
+      groupId: groupId,
+    );
+  }
+}
+
+/// SyncObserver that records every onSourceFailed call so tests can
+/// assert that warm-phase failures are surfaced.
+class RecordingObserver implements SyncObserver {
+  final List<({String sourceId, Object error})> sourceFailures = [];
+
+  @override
+  void onSourceFailed(String sourceId, Object error) {
+    sourceFailures.add((sourceId: sourceId, error: error));
+  }
+
+  @override
+  void onSyncStarted() {}
+  @override
+  void onSampleReceived(TimeSample sample) {}
+  @override
+  void onConsensusReached(ConsensusResult result) {}
+  @override
+  void onSyncFailed(Object error) {}
+  @override
+  void onMetricsReported(SyncMetrics metrics) {}
 }
 
 void main() {
@@ -163,6 +269,253 @@ void main() {
 
         final anchor = await engine.sync();
         expect(anchor.networkUtcMs, closeTo(1000000, 100));
+      },
+    );
+  });
+
+  group('SyncEngine Per-Source Warming Pipeline', () {
+    late MockMonotonicClock clock;
+    late TrustedTimeConfig config;
+
+    setUp(() {
+      clock = MockMonotonicClock();
+      config = const TrustedTimeConfig(
+        minimumQuorum: 2,
+        minGroupCount: 1,
+        ntpServers: [],
+        httpsSources: [],
+      );
+    });
+
+    test(
+      'fast sources are not blocked by a slow sources warming phase '
+      '(no global barrier)',
+      () async {
+        // Three fast sources are needed so that the engine reaches both
+        // consensus quorum (2 samples) and stability (2 consecutive
+        // matching results) before the slow source can finish warming.
+        // This isolates the no-global-barrier property: with a barrier,
+        // sync would block ~500ms; without, it completes in ~50ms.
+        final events = <WarmingEvent>[];
+        final clockSw = Stopwatch()..start();
+
+        WarmingTestSource fast(String id, String group) => WarmingTestSource(
+          id: id,
+          groupId: group,
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+          warmDelay: Duration.zero,
+          getTimeDelay: const Duration(milliseconds: 50),
+        );
+
+        final fast1 = fast('fast1', 'g-fast1');
+        final fast2 = fast('fast2', 'g-fast2');
+        final fast3 = fast('fast3', 'g-fast3');
+        final slow = WarmingTestSource(
+          id: 'slow',
+          groupId: 'g-slow',
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+          warmDelay: const Duration(milliseconds: 500),
+          getTimeDelay: const Duration(milliseconds: 50),
+        );
+
+        final engine = SyncEngine(
+          config: config.copyWith(
+            earlyExit: true,
+            additionalSources: [fast1, fast2, fast3, slow],
+          ),
+          clock: clock,
+        );
+
+        final syncSw = Stopwatch()..start();
+        final anchor = await engine.sync();
+        syncSw.stop();
+        final eventsAtReturn = events.toList();
+
+        expect(anchor.networkUtcMs, inInclusiveRange(999990, 1000020));
+
+        // Primary assertion: sync completes well before the slow source's
+        // warm could possibly finish (500 ms warm).
+        expect(
+          syncSw.elapsedMilliseconds,
+          lessThan(300),
+          reason: 'sync took ${syncSw.elapsedMilliseconds}ms; fast sources '
+              'should not have waited on slow source warming',
+        );
+
+        // Secondary assertion: at the moment sync() returned, the fast
+        // sources had finished getTime, and the slow source's warm had
+        // not yet completed.
+        bool sawPhase(String id, WarmingPhase phase) => eventsAtReturn
+            .any((e) => e.sourceId == id && e.phase == phase);
+        for (final id in ['fast1', 'fast2', 'fast3']) {
+          expect(
+            sawPhase(id, WarmingPhase.getTimeEnd),
+            isTrue,
+            reason: '$id should have completed getTime before sync returned',
+          );
+        }
+        expect(
+          sawPhase('slow', WarmingPhase.warmEnd),
+          isFalse,
+          reason: 'slow.warm-end should not have completed yet; events: '
+              '$eventsAtReturn',
+        );
+      },
+    );
+
+    test(
+      'getTime is never invoked before warm has fully resolved (per-source '
+      'sequential integrity)',
+      () async {
+        final events = <WarmingEvent>[];
+        final clockSw = Stopwatch()..start();
+
+        final sources = [
+          WarmingTestSource(
+            id: 's1',
+            groupId: 'g1',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 30),
+            getTimeDelay: const Duration(milliseconds: 20),
+          ),
+          WarmingTestSource(
+            id: 's2',
+            groupId: 'g2',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 80),
+            getTimeDelay: const Duration(milliseconds: 20),
+          ),
+          WarmingTestSource(
+            id: 's3',
+            groupId: 'g3',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 5),
+            getTimeDelay: const Duration(milliseconds: 20),
+          ),
+        ];
+
+        final engine = SyncEngine(
+          config: config.copyWith(additionalSources: sources),
+          clock: clock,
+        );
+
+        await engine.sync();
+
+        for (final source in sources) {
+          final sourceEvents = events
+              .where((e) => e.sourceId == source.id)
+              .toList();
+          // Expected ordering: warmStart -> warmEnd -> getTimeStart -> getTimeEnd
+          expect(
+            sourceEvents.map((e) => e.phase).toList(),
+            equals([
+              WarmingPhase.warmStart,
+              WarmingPhase.warmEnd,
+              WarmingPhase.getTimeStart,
+              WarmingPhase.getTimeEnd,
+            ]),
+            reason: 'unexpected phase ordering for ${source.id}: '
+                '$sourceEvents',
+          );
+
+          final warmEndAt = sourceEvents
+              .firstWhere((e) => e.phase == WarmingPhase.warmEnd)
+              .atMs;
+          final getTimeStartAt = sourceEvents
+              .firstWhere((e) => e.phase == WarmingPhase.getTimeStart)
+              .atMs;
+          expect(
+            getTimeStartAt,
+            greaterThanOrEqualTo(warmEndAt),
+            reason: '${source.id}: getTime started at ${getTimeStartAt}ms '
+                'before warm finished at ${warmEndAt}ms',
+          );
+        }
+      },
+    );
+
+    test(
+      'synchronous and asynchronous warm failures are reported to the '
+      'observer and do not prevent getTime from running',
+      () async {
+        final events = <WarmingEvent>[];
+        final clockSw = Stopwatch()..start();
+        final observer = RecordingObserver();
+
+        final syncThrower = WarmingTestSource(
+          id: 'syncThrower',
+          groupId: 'g-sync',
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+          throwSyncFromWarm: true,
+        );
+        final asyncThrower = WarmingTestSource(
+          id: 'asyncThrower',
+          groupId: 'g-async',
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+          throwAsyncFromWarm: true,
+        );
+        final healthy1 = WarmingTestSource(
+          id: 'healthy1',
+          groupId: 'g-h1',
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+        );
+        final healthy2 = WarmingTestSource(
+          id: 'healthy2',
+          groupId: 'g-h2',
+          utcMs: 1000000,
+          events: events,
+          clock: clockSw,
+        );
+
+        final engine = SyncEngine(
+          config: config.copyWith(
+            additionalSources: [syncThrower, asyncThrower, healthy1, healthy2],
+          ),
+          clock: clock,
+          observer: observer,
+        );
+
+        final anchor = await engine.sync();
+        expect(anchor.networkUtcMs, inInclusiveRange(999990, 1000020));
+
+        // Both throwers must surface as warm-phase failures on the
+        // observer, tagged with the 'warm:' prefix the engine adds.
+        final warmFailures = observer.sourceFailures
+            .where((f) => f.error.toString().startsWith('warm:'))
+            .toList();
+        final failedIds = warmFailures.map((f) => f.sourceId).toSet();
+        expect(failedIds, containsAll(<String>{'syncThrower', 'asyncThrower'}));
+
+        // Both throwers must still have proceeded to getTime despite the
+        // warm failure.
+        bool sawGetTime(String id) => events
+            .any((e) => e.sourceId == id && e.phase == WarmingPhase.getTimeEnd);
+        expect(
+          sawGetTime('syncThrower'),
+          isTrue,
+          reason: 'syncThrower.getTime did not run after sync warm throw',
+        );
+        expect(
+          sawGetTime('asyncThrower'),
+          isTrue,
+          reason: 'asyncThrower.getTime did not run after async warm throw',
+        );
       },
     );
   });

--- a/test/concurrency_test.dart
+++ b/test/concurrency_test.dart
@@ -519,4 +519,158 @@ void main() {
       },
     );
   });
+
+  group('SyncEngine.warmAllSources', () {
+    late MockMonotonicClock clock;
+    late TrustedTimeConfig config;
+
+    setUp(() {
+      clock = MockMonotonicClock();
+      config = const TrustedTimeConfig(
+        minimumQuorum: 2,
+        minGroupCount: 1,
+        ntpServers: [],
+        httpsSources: [],
+      );
+    });
+
+    test(
+      'invokes warm() on every Warmable source in parallel',
+      () async {
+        final events = <WarmingEvent>[];
+        final clockSw = Stopwatch()..start();
+        final sources = [
+          WarmingTestSource(
+            id: 'a',
+            groupId: 'g-a',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 100),
+          ),
+          WarmingTestSource(
+            id: 'b',
+            groupId: 'g-b',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 100),
+          ),
+          WarmingTestSource(
+            id: 'c',
+            groupId: 'g-c',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 100),
+          ),
+        ];
+
+        final engine = SyncEngine(
+          config: config.copyWith(additionalSources: sources),
+          clock: clock,
+        );
+
+        final sw = Stopwatch()..start();
+        await engine.warmAllSources();
+        sw.stop();
+
+        // All three sources must have completed warming.
+        for (final id in ['a', 'b', 'c']) {
+          expect(
+            events.any(
+              (e) => e.sourceId == id && e.phase == WarmingPhase.warmEnd,
+            ),
+            isTrue,
+            reason: '$id.warm-end was not recorded',
+          );
+        }
+
+        // Parallelism: 3 x 100ms warms must take ~100ms, not ~300ms.
+        // 250ms is generous enough to absorb scheduling jitter on
+        // slow CI without admitting accidental sequential execution.
+        expect(
+          sw.elapsedMilliseconds,
+          lessThan(250),
+          reason: 'warmAllSources took ${sw.elapsedMilliseconds}ms; '
+              'expected ~100ms (parallel) not ~300ms (sequential)',
+        );
+      },
+    );
+
+    test(
+      'is a no-op when no source implements Warmable',
+      () async {
+        final source = RaceConditionSource(
+          'plain',
+          Duration.zero,
+          1000000,
+        );
+
+        final engine = SyncEngine(
+          config: config.copyWith(additionalSources: [source]),
+          clock: clock,
+        );
+
+        final sw = Stopwatch()..start();
+        await engine.warmAllSources();
+        sw.stop();
+
+        expect(sw.elapsedMilliseconds, lessThan(50));
+      },
+    );
+
+    test(
+      'swallows individual warm failures so a misbehaving source cannot '
+      'block bootstrap',
+      () async {
+        final events = <WarmingEvent>[];
+        final clockSw = Stopwatch()..start();
+        final sources = [
+          WarmingTestSource(
+            id: 'syncThrower',
+            groupId: 'g-sync',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            throwSyncFromWarm: true,
+          ),
+          WarmingTestSource(
+            id: 'asyncThrower',
+            groupId: 'g-async',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            throwAsyncFromWarm: true,
+          ),
+          WarmingTestSource(
+            id: 'healthy',
+            groupId: 'g-healthy',
+            utcMs: 1000000,
+            events: events,
+            clock: clockSw,
+            warmDelay: const Duration(milliseconds: 30),
+          ),
+        ];
+
+        final engine = SyncEngine(
+          config: config.copyWith(additionalSources: sources),
+          clock: clock,
+        );
+
+        // Must not throw.
+        await engine.warmAllSources();
+
+        // Healthy source must still have completed warming.
+        expect(
+          events.any(
+            (e) =>
+                e.sourceId == 'healthy' && e.phase == WarmingPhase.warmEnd,
+          ),
+          isTrue,
+          reason: 'healthy.warm-end did not run despite sibling failures',
+        );
+      },
+    );
+  });
 }

--- a/test/concurrency_test.dart
+++ b/test/concurrency_test.dart
@@ -167,24 +167,3 @@ void main() {
     );
   });
 }
-
-extension on TrustedTimeConfig {
-  TrustedTimeConfig copyWith({
-    List<TimeSource>? additionalSources,
-    int? minimumQuorum,
-    bool? earlyExit,
-    int? minGroupCount,
-  }) {
-    return TrustedTimeConfig(
-      ntpServers: ntpServers,
-      httpsSources: httpsSources,
-      additionalSources: additionalSources ?? this.additionalSources,
-      minimumQuorum: minimumQuorum ?? this.minimumQuorum,
-      earlyExit: earlyExit ?? this.earlyExit,
-      minGroupCount: minGroupCount ?? this.minGroupCount,
-      persistState: persistState,
-      refreshInterval: refreshInterval,
-      maxLatency: maxLatency,
-    );
-  }
-}


### PR DESCRIPTION
## Summary

Five closely-related changes to make `package:nts` viable as a first-
class source in `SyncEngine`:

1. **`TrustedTimeConfig.copyWith` helper.** Adds a forward-compatible
   immutable-update method on `TrustedTimeConfig`, used by change (4)
   below. Originally proposed as standalone PR #13 and folded into
   this PR so the engine work and its prerequisite ship as a single
   reviewable unit.
2. **Startup FRB init.** `TrustedTime.initialize()` now calls
   `nts.RustLib.init()` once, gated on `ntsServers.isNotEmpty`, so the
   first `NtsSource` construction does not pay the `flutter_rust_bridge`
   lazy-init cost on the critical path of the first sync.
3. **Per-source two-phase warming pipeline.** `SyncEngine` now warms
   and queries each source in its own concurrent task with no global
   barrier between phases. Sources with no-op warming (NTP/HTTPS) reach
   the consensus stream immediately rather than waiting on the slowest
   warm; NTS-KE handshakes no longer block the rest of the pool.
4. **Widened sync deadline + safe NTS-disable fallback.** The outer
   `sync()` deadline is widened to `maxLatency + 6s` so NTS-KE
   handshakes have a realistic window. When `RustLib.init` fails, the
   engine clears `ntsServers` via the new `copyWith` helper rather
   than reconstructing the config field-by-field, which was fragile
   to future field additions.
5. **Eager warming during `initialize()`.** Adds
   `SyncEngine.warmAllSources()` and awaits it in `_bootstrap()`, so
   per-source warm state (e.g., NTS cookie jars and TLS handshakes)
   is primed before the first sync cycle runs. Without this, the
   first cycle's per-source pipeline (change 3 above) still pays
   the warm cost on the JIT path, which folds the handshake duration
   into the round-trip estimate that anchors each NTS sample's
   interval midpoint and biases cold-start centres off true UTC.

## Why

Before this work, four issues made NTS impractical:

- The first sync paid an unbounded FRB-asset-load cost, occasionally
  several hundred milliseconds, on the critical path of the very first
  `getTime()` request.
- A global `Future.wait` barrier in `SyncEngine` forced fast sources
  (NTP/HTTPS) to wait on the slowest source's warming phase. With NTS
  in the pool, this meant every cycle paid the worst-case NTS-KE
  handshake latency, even when fast sources had already produced
  samples sufficient for high-confidence consensus.
- The outer `sync()` deadline was sized for fast sources only, so
  cold-start NTS-KE handshakes routinely tripped it and left the
  engine in `syncFailed`.
- Even with the per-source pipeline, the first sync cycle's NTS
  samples carried hundreds of milliseconds of midpoint bias because
  the NTS-KE handshake ran inside the cycle's wall clock and
  contaminated each sample's RTT estimate. Cold-start cycles
  consequently failed quorum (Marzullo refused to merge non-overlapping
  midpoints) even though all sources returned authenticated samples.

## Design notes

The `Warmable` interface is defined separately from `TimeSource` so
third-party `TimeSource` implementations remain source-compatible. NTS
is the only built-in source that currently implements it; its `warm()`
memoizes a single `_warmTask` so concurrent or repeated invocations
share the same handshake. NTP and HTTPS sources do not implement
`Warmable` and are queried immediately.

`TrustedTimeConfig.copyWith` covers all 15 configuration fields. One
documented limitation: `backgroundSyncInterval` cannot be cleared back
to `null` via `copyWith`; callers needing that edge case should
construct a new instance directly. This is called out in the dartdoc.
The chore branch's local test-only `copyWith` extension in
`concurrency_test.dart` is removed since the production method now
shadows it.

`SyncEngine.warmAllSources()` shares the same per-source failure
swallow semantics as the warm phase inside `sync()`: a misbehaving
source cannot block bootstrap, and `sync()` retains its existing
JIT-warm fallback path so the engine is robust to a partial or
skipped eager warm.

## Commit history

Four logically distinct commits, ordered for clean review:

1. `chore(models): add TrustedTimeConfig.copyWith` — pure API addition
2. `feat(nts,sync): startup FRB init + per-source two-phase warming
   pipeline` — engine changes that consume `copyWith` on the
   NTS-disable fallback path
3. `test(sync): coverage for the per-source two-phase warming pipeline`
   — 13 new tests across three behavioural groups
4. `feat(sync): eager-warm Warmable sources during initialize()` —
   adds `warmAllSources()` and awaits it in `_bootstrap()`; 3 new
   tests for the eager-warming contract

## What changed

- `lib/src/models.dart`: adds `copyWith` (44 lines incl. dartdoc)
- `lib/src/domain/time_source.dart`: introduces `abstract interface
  class Warmable { Future<void> warm(); }`
- `lib/src/sources/nts_source.dart`: implements `Warmable`; `warm()`
  memoizes `_warmTask` for idempotency
- `lib/src/sync_engine.dart`: per-source pipeline; widened outer
  deadline; new `warmAllSources()` method
- `lib/trusted_time.dart`: `RustLib.init()` on startup with
  `copyWith`-based NTS-disable fallback
- `lib/src/trusted_time_impl.dart`: awaits `warmAllSources()` in
  `_bootstrap()` after observers are bound and before persisted
  state is loaded
- `test/concurrency_test.dart`: removes 21-line test-only `copyWith`
  extension; adds 353 lines of pipeline coverage plus 158 lines for
  the eager-warming contract

## Test plan

- [x] `flutter analyze` (root + example): clean
- [x] `flutter test` (root): 68 tests pass, including:
  - 13 pipeline tests covering:
    - Fast sources are not blocked by a slow source's warming phase
      (no global barrier)
    - `getTime` is never invoked before that source's `warm` has fully
      resolved (per-source sequential integrity)
    - Synchronous and asynchronous warm failures are reported to the
      observer via `onSourceFailed(id, 'warm: ...')` and do not prevent
      `getTime` from running on other sources
  - 3 eager-warming tests covering:
    - `warmAllSources()` invokes `warm()` on every Warmable source in
      parallel (3 x 100ms sources complete in <250ms, not ~300ms)
    - `warmAllSources()` is a no-op when no source implements Warmable
    - `warmAllSources()` swallows individual warm failures so a
      misbehaving source cannot block bootstrap
- [x] `flutter test` (example): all pass
- [x] End-to-end validation on a physical Pixel Tablet (NTS-only
      curated 5-source pool, 16 cycles):
  - Cold-start cycle (cycle 1): all four selected NTS sources
    contribute, consensus reached at `participants=4 groups=4
    ±24ms latency=174ms confidence=high` — eliminating the
    `participants=1 groups=2 ±33ms latency=1121ms confidence=medium`
    cold-start signature observed before eager warming.
  - Steady-state cycles (2-16): every cycle reaches consensus,
    `confidence=high` on 15/16 cycles. Verbose `rustls` traces
    confirm all NTS-KE handshakes complete during the bootstrap
    phase, well before the first `syncStarted` event.

## Notes

Supersedes #13, which proposed `copyWith` as a standalone change.
Closing #13 in favour of this consolidated PR.
