### PR TITLE
feat(nts): upgrade to nts ^2.0.0, log phaseTimings, bypass cooldown on DnsSaturation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: nts
-      sha256: d484cf32d8c08fda4eef676be45bb07fe016e47032a486c0f1919936e712415a
+      sha256: ba5acfa1e0dbb00b739e97c318b357ddad22877970000250b3fc61ec8f1c6d10
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "2.0.0"
   objective_c:
     dependency: transitive
     description:

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -67,3 +67,23 @@ final class TrustedTimePersistenceException implements Exception {
   @override
   String toString() => 'TrustedTimePersistenceException: $message';
 }
+
+/// Thrown by a `TimeSource` to signal that the failure was transient and
+/// the source should be retried on the next sync cycle without the
+/// exponential cooldown that other failures incur.
+///
+/// Example: an `NtsSource` whose `ntsQuery` returned
+/// `NtsError.timeout(TimeoutPhase.dnsSaturation)` because the bounded DNS
+/// resolver pool was momentarily full. The host itself is healthy; the
+/// next cycle will probably succeed once peers release their resolver
+/// slots, so blacklisting the source for minutes would be incorrect.
+final class TransientSourceError implements Exception {
+  /// Creates a [TransientSourceError] wrapping the underlying [cause].
+  const TransientSourceError(this.cause);
+
+  /// The original error that the source classified as transient.
+  final Object cause;
+
+  @override
+  String toString() => 'TransientSourceError: $cause';
+}

--- a/lib/src/sources/nts_source.dart
+++ b/lib/src/sources/nts_source.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:nts/nts.dart' as nts;
 
 import '../domain/time_sample.dart';
 import '../domain/time_source.dart';
 import '../domain/time_interval.dart';
+import '../exceptions.dart';
 import '../models.dart';
 import 'nts_auth_level.dart';
 
@@ -24,10 +26,25 @@ import 'nts_auth_level.dart';
 /// empty (the default), no NTS connections are made.
 final class NtsSource implements TimeSource {
   /// Creates an NTS source for the given NTS-KE server.
-  NtsSource(this._host, {int port = 4460}) : _port = port;
+  ///
+  /// [maxLatency] is forwarded as `ntsQuery`'s `timeoutMs`. [SyncEngine]
+  /// passes [TrustedTimeConfig.maxLatency] so the inner per-query budget
+  /// matches the outer `.timeout(_config.maxLatency)` wrapper. Without
+  /// this, an inner timeout longer than the outer would always be
+  /// pre-empted by Dart's `TimeoutException`, swallowing the
+  /// phase-tagged `NtsError.timeout(TimeoutPhase)` payload that drives
+  /// the [TransientSourceError] cooldown-bypass path. The default of 5 s
+  /// preserves the prior hardcoded behaviour for direct callers.
+  NtsSource(
+    this._host, {
+    int port = 4460,
+    Duration maxLatency = const Duration(seconds: 5),
+  }) : _port = port,
+       _timeoutMs = maxLatency.inMilliseconds;
 
   final String _host;
   final int _port;
+  final int _timeoutMs;
 
   @override
   String get id => '${TimeSource.prefixNts}$_host';
@@ -42,11 +59,36 @@ final class NtsSource implements TimeSource {
 
   @override
   Future<TimeSample> getTime() async {
-    // Use package:nts for full RFC 8915 compliant NTS query
-    final result = await nts.ntsQuery(
-      spec: nts.NtsServerSpec(host: _host, port: _port),
-      timeoutMs: 5000,
-    );
+    final nts.NtsTimeSample result;
+    try {
+      result = await nts.ntsQuery(
+        spec: nts.NtsServerSpec(host: _host, port: _port),
+        timeoutMs: _timeoutMs,
+      );
+    } on nts.NtsError_Timeout catch (e) {
+      // Dns(Saturation) means the bounded DNS resolver pool was at
+      // capacity for this call. The host itself is healthy; SyncEngine
+      // should retry on the next cycle without applying exponential
+      // cooldown. Other timeout phases (Connect, Tls, KeRecordIo, Ntp,
+      // DnsTimeout) propagate as-is and follow the standard cooldown
+      // path.
+      if (e.field0 == nts.TimeoutPhase.dnsSaturation) {
+        throw TransientSourceError(e);
+      }
+      rethrow;
+    }
+
+    if (kDebugMode) {
+      final p = result.phaseTimings;
+      debugPrint(
+        '[TrustedTime] nts:$_host '
+        'rtt=${(result.roundTripMicros / 1000).toStringAsFixed(1)}ms '
+        'dns=${(p.dnsMicros / 1000).toStringAsFixed(1)}ms '
+        'connect=${(p.connectMicros / 1000).toStringAsFixed(1)}ms '
+        'tls=${(p.tlsHandshakeMicros / 1000).toStringAsFixed(1)}ms '
+        'ke=${(p.keRecordIoMicros / 1000).toStringAsFixed(1)}ms',
+      );
+    }
 
     // Calculate uncertainty from network RTT (convert microseconds to milliseconds)
     final uncertaintyMs = result.roundTripMicros ~/ 2000;

--- a/lib/src/sources/nts_source_stub.dart
+++ b/lib/src/sources/nts_source_stub.dart
@@ -4,7 +4,11 @@ import '../domain/time_source.dart';
 /// NTS time source stub — actual implementation in `nts_source.dart`.
 final class NtsSource implements TimeSource {
   /// Documented.
-  NtsSource(this._host, {int port = 4460});
+  NtsSource(
+    this._host, {
+    int port = 4460,
+    Duration maxLatency = const Duration(seconds: 5),
+  });
 
   final String _host;
 

--- a/lib/src/sync_engine.dart
+++ b/lib/src/sync_engine.dart
@@ -51,7 +51,7 @@ final class SyncEngine {
     for (final host in _config.ntpServers) NtpSource(host),
     for (final url in _config.httpsSources) HttpsSource(url),
     for (final host in _config.ntsServers)
-      NtsSource(host, port: _config.ntsPort),
+      NtsSource(host, port: _config.ntsPort, maxLatency: _config.maxLatency),
     ..._config.additionalSources,
   ];
 
@@ -333,6 +333,14 @@ final class SyncEngine {
       _sourceHealth[source.id] = 0; // Reset failure count on success
       _blacklistUntil.remove(source.id);
       return sample;
+    } on TransientSourceError catch (e) {
+      // Source classified the failure as transient (e.g. NtsSource saw
+      // NtsError.timeout(TimeoutPhase.dnsSaturation): the DNS resolver
+      // pool was momentarily full). Notify the observer but do not bump
+      // the failure score or blacklist the host — the next sync cycle
+      // is expected to succeed once contention clears.
+      _observer?.onSourceFailed(source.id, e);
+      return null;
     } catch (e) {
       _observer?.onSourceFailed(source.id, e);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  nts: ^1.3.1
+  nts: ^2.0.0
   http: ">=1.0.0 <2.0.0"
   flutter_secure_storage: ^10.0.0
   ntp: ^2.0.0


### PR DESCRIPTION
Replaces #12. That PR proposed bumping `nts` from `^1.3.1` to `^1.4.0` to fix the Android `rustls-platform-verifier` panic during the first NTS-KE handshake. This PR upgrades directly to `^2.0.0` instead, which ships the same Android fix plus two new diagnostic surfaces that materially change what `NtsSource` can do.

## Why v2.0.0 and not v1.4.0

`nts` 2.0.0 is the version the maintainer themselves released, so landing here on v1.4.0 would mean shipping an interim version that's already been superseded. v2.0.0 also adds:

- **`NtsTimeSample.phaseTimings: PhaseTimings`** — microsecond-resolution wall-clock breakdown of the four pre-NTP phases (`dnsMicros`, `connectMicros`, `tlsHandshakeMicros`, `keRecordIoMicros`). Lets operators attribute residual long-tail latency (e.g. one host being consistently 700-900 ms slower than its peers) to a specific phase without needing to instrument with a `Stopwatch`.
- **`NtsError.timeout(TimeoutPhase)`** — phase-tagged timeout payload with variants `dnsSaturation`, `dnsTimeout`, `connect`, `tls`, `keRecordIo`, `ntp`. Replaces the prior nullary `NtsError.timeout()`.

This PR integrates both surfaces into `NtsSource`, including a behavioural change that materially improves resilience (cooldown bypass on `dnsSaturation`).

## Changes

1. **`pubspec.yaml`**: `nts: ^1.3.1` → `nts: ^2.0.0`.

2. **`lib/src/exceptions.dart`**: new `TransientSourceError` marker exception. Sources throw it to signal the engine that a failure was transient and the source should be retried on the next sync cycle without exponential cooldown. Added to the existing wildcard export in `lib/trusted_time.dart` for consistency with the other public exception types in the same file (`TrustedTimeNotReadyException`, `TrustedTimeSyncException`, etc.) — third-party `TimeSource` implementations supplied via `TrustedTimeConfig.additionalSources` need to be able to throw it from `getTime()`.

3. **`lib/src/sources/nts_source.dart`**:
   - New `Duration maxLatency` constructor parameter forwarded as `ntsQuery`'s `timeoutMs`. `SyncEngine` passes `_config.maxLatency` so the inner per-query budget matches the outer `.timeout(_config.maxLatency)` wrapper. **Without this coordination, the prior hardcoded `timeoutMs: 5000` was always pre-empted by Dart's outer `TimeoutException` (default `maxLatency = 4s`), swallowing the phase-tagged `NtsError.timeout(TimeoutPhase)` payload before it reached `NtsSource`'s catch arm**.
   - Wraps `ntsQuery` in `try { ... } on nts.NtsError_Timeout catch (e)`. When the phase tag is `dnsSaturation` (a synchronous admission failure from the bounded resolver pool), rethrows as `TransientSourceError` so the engine bypasses cooldown. All other timeout phases propagate as-is.
   - On every successful query, emits `if (kDebugMode) debugPrint(...)` containing the four phase microseconds plus RTT.

4. **`lib/src/sources/nts_source_stub.dart`**: mirrors the `maxLatency` constructor parameter so the non-IO platform fallback compiles.

5. **`lib/src/sync_engine.dart`**:
   - Constructs each `NtsSource` with `maxLatency: _config.maxLatency`.
   - `_querySafe` adds an `on TransientSourceError catch (e)` arm before the generic catch. The arm notifies the observer but does not bump `_sourceHealth` or set `_blacklistUntil`, so a momentary DNS pool saturation no longer blacklists an otherwise-healthy host for minutes.

6. **`example/pubspec.lock`**: auto-regenerated to resolve `nts 2.0.0`.

## Compatibility

- `NtsTimeSample`'s constructor gains a required `phaseTimings` field in v2.0.0. No tracked tests construct `NtsTimeSample` directly, so no fixtures break.
- `nts_warm_cookies` (not used by `NtsSource` on this branch) changed return type from `Future<int>` to `Future<NtsWarmCookiesOutcome>` — does not affect this PR.
- `NtsError.timeout()` (nullary) → `NtsError.timeout(TimeoutPhase field0)`. The new `try { ... } on NtsError_Timeout` arm consumes this directly.

## Verification

- `flutter analyze` (root + example): clean
- `flutter test` (root): 62 / 62 pass
- `flutter test` (example): 1 / 1 passes
- `flutter pub get`: `nts 2.0.0` resolves cleanly with no transitive conflicts.

## Behavioural impact summary

| Surface | Before | After |
|---|---|---|
| Android first-handshake panic | crashes (`rustls-platform-verifier` not initialised) | fixed (carried over from v1.4.0) |
| Long-tail latency attribution | invisible — only `roundTripMicros` exposed | per-phase microseconds in debug logs |
| Timeout payload | generic Dart `TimeoutException` (outer wrapper fired first) | phase-tagged `NtsError.timeout(TimeoutPhase)` reaches the catch arm |
| DNS pool saturation | blacklists the host for 2-128 minutes via exponential cooldown | observer notified, source retried on next cycle, no cooldown |
| Resource leak on outer-timeout | `ntsQuery` continued running ~1 s past engine's outer timeout | inner timeout fires first, query terminates cleanly |
